### PR TITLE
Added command for strict testing

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
+    "test-strict": "npm run check-eslint-config && npm run check-code && npm run test",
     "test-with-cov": "jest && codecov",
     "start": "webpack-dev-server --config internals/webpack/webpack.dev.js",
     "start:prod": "webpack-dev-server --config internals/webpack/webpack.prod.js",


### PR DESCRIPTION
La till kommando för att köra tester i ett "strikt" läge. Både formattering och enhetstester kommer då att kollas, vilket är vad Travis stämmer av innan den lämnar en rapport. Klarar du att köra testerna i strikt läge utan fel så kommer Travis garanterat att gå igenom. 😎