### PR TITLE
fix: Updated travis badge in README to point at correct repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 [![Build Status](https://travis-ci.com/MarkusPettersson98/togepi_code.svg?token=RxZAchiihLHxz8ayzFcW&branch=dev)](https://travis-ci.com/MarkusPettersson98/togepi_code)
 [![codecov](https://codecov.io/gh/DorisIT/togepi_code/branch/master/graph/badge.svg?token=BRxHIoPHpk)](https://codecov.io/gh/DorisIT/togepi_code)
 
-Tekniskt dokument: https://gist.github.com/DorisIT/84638d4ff5595886404e03c3a7da6ef8
+Tekniskt dokument: https://gist.github.com/MarkusPettersson98/84638d4ff5595886404e03c3a7da6ef8


### PR DESCRIPTION
Since I changed name on GitHub the link of the travis badge in our
README broke. Whoops 😕