### PR TITLE
fix: missed important import, not crashing anymore

### DIFF
--- a/App/pages/Checkout.js
+++ b/App/pages/Checkout.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { AntDesign } from '@expo/vector-icons';
 import { addCoffee } from './components/redux/actions';
 import CheckoutItem from './components/checkout/CheckoutItem';
+import EmptycheckoutPage from './components/checkout/emptyCheckout';
 
 const CheckoutPage = props => {
     return (


### PR DESCRIPTION
Failed to import before, now the application doesn't crash if you click the checkout icon