### PR TITLE
Dispatcher now carries the same payload to cart.

### DIFF
--- a/App/pages/components/checkout/CheckoutItem.js
+++ b/App/pages/components/checkout/CheckoutItem.js
@@ -17,11 +17,11 @@ const CheckoutItem = props => {
               //onPress: () => console.log('Cancel Pressed'),
               style: 'cancel',
             },
-            {text: 'OK', onPress: () => props.onDecrementCoffee(orderItem)},
+            {text: 'OK', onPress: () => props.onDecrementCoffee(orderItem.coffee)},
           ]
         );
       }
-      return props.onDecrementCoffee(orderItem)
+      return props.onDecrementCoffee(orderItem.coffee)
     }
 
     return (
@@ -71,7 +71,7 @@ const CheckoutItem = props => {
                     <Text style={styles.numberText}>{orderItem.amount}</Text>
 
                     <TouchableOpacity
-                        onPress={() => props.onIncrementCoffee(orderItem)}
+                        onPress={() => props.onIncrementCoffee(orderItem.coffee)}
                         hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}
                     >
                         <AntDesign
@@ -127,11 +127,11 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
     return {
-        onIncrementCoffee: orderItem => {
-            dispatch(incrementCoffee(orderItem));
+        onIncrementCoffee: coffee => {
+            dispatch(incrementCoffee(coffee));
         },
-        onDecrementCoffee: orderItem => {
-            dispatch(decrementCoffee(orderItem));
+        onDecrementCoffee: coffee => {
+            dispatch(decrementCoffee(coffee));
         },
     };
 };

--- a/App/pages/components/checkout/NonEmptyCheckout.js
+++ b/App/pages/components/checkout/NonEmptyCheckout.js
@@ -79,7 +79,8 @@ export const getTotalOrder = orderItems => {
     // check if the orderItem is an empty object using
     // https://coderwall.com/p/_g3x9q/how-to-check-if-javascript-object-is-empty
     if (Object.keys(orderItems).length) {
-		// loop through object using https://stackoverflow.com/a/5737192
+        // loop through object using https://stackoverflow.com/a/5737192
+        console.log(Object.keys(orderItems));
         Object.keys(orderItems).forEach(function(key) {
             total = total + orderItems[key].coffee.price * orderItems[key].amount;
         });

--- a/App/pages/components/redux/actions.js
+++ b/App/pages/components/redux/actions.js
@@ -14,12 +14,12 @@ export const ITEM_DECREMENT = 'ITEM_DECREMENT';
  * action creators
  */
 
-export function incrementCoffee(orderItem) {
-    return { type: ITEM_INCREMENT, orderItem };
+export function incrementCoffee(coffee) {
+    return { type: ITEM_INCREMENT, coffee };
 }
 
-export function decrementCoffee(orderItem) {
-    return { type: ITEM_DECREMENT, orderItem };
+export function decrementCoffee(coffee) {
+    return { type: ITEM_DECREMENT, coffee };
 }
 
 export function addCoffee(coffee) {

--- a/App/pages/components/redux/reducers.js
+++ b/App/pages/components/redux/reducers.js
@@ -19,45 +19,39 @@ import {
 export const INITIAL_STATE = {};
 
 export function cart(orderItems = INITIAL_STATE, action) {
-    let existingItem;
     let id;
+    let existingItem;
+
     switch (action.type) {
         case CART_ADD_COFFEE:
+        case ITEM_INCREMENT:
             id = action.coffee.id;
             existingItem = orderItems[id];
-            return Object.assign({}, orderItems, {
+
+            return {
+                ...orderItems,
                 [id]: {
                     coffee: action.coffee,
                     amount: existingItem ? existingItem.amount + 1 : 1,
                 },
-            });
-
-        case ITEM_INCREMENT:
-            id = action.orderItem.coffee.id;
-            existingItem = orderItems[id];
-
-            return Object.assign({}, orderItems, {
-                [id]: {
-                    coffee: action.orderItem.coffee,
-                    amount: existingItem ? existingItem.amount + 1 : 1,
-                },
-            });
+            };
 
         case ITEM_DECREMENT:
-            id = action.orderItem.coffee.id;
+            id = action.coffee.id;
             existingItem = orderItems[id];
             if (existingItem.amount == 1) {
                 // Delete item
                 let newState = Object.assign({}, orderItems);
                 delete newState[id];
                 return newState;
+            } else {
+                return Object.assign({}, orderItems, {
+                    [id]: {
+                        coffee: action.coffee,
+                        amount: existingItem ? existingItem.amount - 1 : 1,
+                    },
+                });
             }
-            return Object.assign({}, orderItems, {
-                [id]: {
-                    coffee: action.orderItem.coffee,
-                    amount: existingItem ? existingItem.amount - 1 : 1,
-                },
-            });
 
         case CART_CLEAR:
             return {};

--- a/App/pages/components/redux/redux.test/reducers.test.js
+++ b/App/pages/components/redux/redux.test/reducers.test.js
@@ -26,7 +26,7 @@ test('add a brygg_kaffe to a cart with 1 (one) brygg_kaffe in it', () => {
 
 test('increment brygg_kaffe to a cart with 1 (one) brygg_kaffe in it', () => {
     expect(
-        cart(brygg_kaffe_in_cart, incrementCoffee(brygg_kaffe_in_cart['123'])),
+        cart(brygg_kaffe_in_cart, incrementCoffee(brygg_kaffe)),
     ).toEqual(two_brygg_kaffe_in_cart);
 });
 
@@ -34,7 +34,7 @@ test('decrement brygg_kaffe to a cart with 2 (two) brygg_kaffe in it', () => {
     expect(
         cart(
             two_brygg_kaffe_in_cart,
-            decrementCoffee(two_brygg_kaffe_in_cart['123']),
+            decrementCoffee(brygg_kaffe),
         ),
     ).toEqual({
         '123': {
@@ -61,7 +61,7 @@ test('decrement 1 (one) cappuchino from a cart with 2 (two) brygg_kaffe and 1 (o
     expect(
         cart(
             two_brygg_kaffe_one_cappuchino_in_cart,
-            decrementCoffee(two_brygg_kaffe_one_cappuchino_in_cart['124']),
+            decrementCoffee(cappuccino),
         ),
     ).toEqual({
         '123': {
@@ -75,7 +75,7 @@ test('decrement brygg_kaffe from a cart with 2 (two) brygg_kaffe and 1 (one) cap
     expect(
         cart(
             two_brygg_kaffe_one_cappuchino_in_cart,
-            decrementCoffee(two_brygg_kaffe_one_cappuchino_in_cart['123']),
+            decrementCoffee(brygg_kaffe),
         ),
     ).toEqual({
         '123': {


### PR DESCRIPTION
Istället för att skicka orderItems till reducer så skickar vi nu kaffe-objekt. Detta innebär att reducern är mer förutsägbar och tacksammare att testa.

Exempelvis byts testning ut
`cart(brygg_kaffe_in_cart, incrementCoffee(brygg_kaffe_in_cart['123'])),`
mot 
`cart(brygg_kaffe_in_cart, incrementCoffee(brygg_kaffe)),`

och
`export function incrementCoffee(orderItem) {	`
   `      return { type: ITEM_INCREMENT, orderItem };	`
`}`
mot
`export function incrementCoffee(coffee) {`
 `    return { type: ITEM_INCREMENT, coffee };`
`}`

Se även i reducer.js skillnaden

Det innebär helt enkelt att vi skickar runt färre/mindre data, och testning blir simplare. 👍 