### PR TITLE
In Checkout, if emptying, dynamically show empty view instead

### DIFF
--- a/App/pages/Checkout.js
+++ b/App/pages/Checkout.js
@@ -27,7 +27,7 @@ class CheckoutPage extends React.Component {
     // Intended effect:  If props is updated this function is called, we check if cart is empty, if empty, update the component (re-render)
     shouldComponentUpdate(nextProps) {
         // if and ONLY if newCart is empty AND the current cart is NOT empty: we update state and rerender.
-        if (nextProps.cart.amount === 0 && this.state.isCartPopulated !== 0) {
+        if (this.state.isCartPopulated !== 0 && nextProps.cart.amount === 0) {
             this.setState({ isCartPopulated: nextProps.cart.amount });
             return true;
         }


### PR DESCRIPTION
# Ändrade vad som hände då ens cart blev tom i checkout

Om man klickar på empty cart eller decrementar sista kaffen så visas nu istället

## Nu i rerenderCheckout
<img src="https://user-images.githubusercontent.com/31474146/57585542-f6e64980-74e9-11e9-891c-f1005460ca08.png" width="30%" height="30%">

## Istället för det gamla i dev
<img src="https://user-images.githubusercontent.com/31474146/57585543-f6e64980-74e9-11e9-94e8-bf10b3d9283e.png" width="30%" height="30%">