### PR TITLE
clearCheckoutButton fix for new redux state

### DIFF
--- a/App/pages/components/header/ClearCheckoutIcon.js
+++ b/App/pages/components/header/ClearCheckoutIcon.js
@@ -6,7 +6,7 @@ import { clearCart } from '../redux/actions';
 
 const ClearCheckout = ({ cart, dispatch }) => {
     // checks if the cart is emtpy using the length of keys, 0 being 'falsy'
-    const emptyCart = !Object.keys(cart).length;
+    const emptyCart = !cart.amount;
     const checkClearCart = () => {
         return Alert.alert(
             'Varning',


### PR DESCRIPTION
För att disabla varukorgsrensning när carten är tom.