### PR TITLE
Refaktorering av tester

### DIFF
--- a/App/API/API.test/expressoAPI.test.js
+++ b/App/API/API.test/expressoAPI.test.js
@@ -45,6 +45,12 @@ describe('Testing if getShop returns the right shop', () => {
             expect(data.name).toEqual('Wijkanders'),
         );
     });
+
+    it('Should output nothing', () => {
+        return getShop('abc123').then(data =>
+            expect(data).toEqual([]),
+        );
+    });
 });
 
 describe('Testing if all the coffeesorts from a shop is printed out ', () => {


### PR DESCRIPTION
Våra tester har visat sig vara så jävla stela, Travis smäller så fort vi lägger till data till våra butiker ..

## Changes
Vi går över till att testa mer properties kring vårt APIs returvärden, snarare än att jämföra objekt med varandra.