### PR TITLE
Tillbaka-pilar istället för text (som är default i react-navigation)

### DIFF
--- a/App/pages/Navigation.js
+++ b/App/pages/Navigation.js
@@ -6,6 +6,7 @@ import {
     createAppContainer,
 } from 'react-navigation';
 
+
 import Homepage from './Homepage';
 import Profilepage from './ProfilePage';
 import OrderPage from './OrderPage';
@@ -13,6 +14,7 @@ import Checkout from './Checkout';
 import ClearCheckoutHeader from './components/header/ClearCheckoutIcon';
 import Cafe from './components/cafe/Cafe';
 import ExpressoLogoHeader from './components/header/ExpressoLogo';
+import BackArrow from './components/header/BackArrow'
 import { Feather, MaterialIcons } from '@expo/vector-icons';
 import CartField from './components/CartField';
 
@@ -29,6 +31,7 @@ const headerStyling = {
 const headerIconStyling = {
     size: 32,
     color: '#F0F7F4',
+    margin: 5,
 };
 
 const tabIconStyling = {
@@ -163,14 +166,15 @@ export const RootStack = createStackNavigator(
             screen: Tabs,
             navigationOptions: ({ navigation }) => ({
                 headerTitle: <ExpressoLogoHeader />,
-                title: 'Startsida',
+                title: ' ',
                 ...headerStyling,
             }),
         },
         Checkout: {
           screen: Checkout,
           navigationOptions: ({ navigation }) => ({
-              headerRight: <ClearCheckoutHeader />,
+              headerRight: <ClearCheckoutHeader styling={headerIconStyling}/>,
+              headerLeft: <BackArrow styling={headerIconStyling}/>,
               title: 'Betalning',
               ...headerStyling,
           }),
@@ -178,6 +182,7 @@ export const RootStack = createStackNavigator(
         Cafe: {
             screen: Cafe,
             navigationOptions: ({ navigation }) => ({
+                headerLeft: <BackArrow styling={headerIconStyling}/>,
                 ...headerStyling,
             }),
         },

--- a/App/pages/components/header/BackArrow.js
+++ b/App/pages/components/header/BackArrow.js
@@ -1,22 +1,20 @@
 import React from 'react';
 import { View, TouchableOpacity } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { withNavigation } from 'react-navigation';
 
-const Drawer = props => {
-    //Structure for the navigatin Drawer
-    const toggleDrawer = navigationProps => {
-        //Props to open/close the drawer
-        navigationProps.toggleDrawer();
-    };
+const BackArrow = props => {
     return (
-        <View style={{ flexDirection: 'row', margin: 5 }}>
+        <View style={{ flexDirection: 'row', margin: props.styling.margin }}>
             <TouchableOpacity
-                onPress={() => toggleDrawer(props.navigationProps)}
+                onPress={() => {
+                    props.navigation.goBack();
+                }}
                 hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
             >
                 {/*Donute Button Image */}
                 <Ionicons
-                    name="ios-menu"
+                    name="ios-arrow-back"
                     size={props.styling.size}
                     color={props.styling.color}
                 />
@@ -25,4 +23,4 @@ const Drawer = props => {
     );
 };
 
-export default Drawer;
+export default withNavigation(BackArrow);


### PR DESCRIPTION
Nu har vi pilar som navigerar bakåt istället i headern, placeringen kan förmodligen förbättras, men @raspudic  take it away ;) 

<img src="https://user-images.githubusercontent.com/31474146/58049515-56c59b80-7b4d-11e9-9b41-1e7d2d9bb786.png" width="30%" height="30%">
<img src="https://user-images.githubusercontent.com/31474146/58049516-56c59b80-7b4d-11e9-8e72-8a1047e4acab.png" width="30%" height="30%">

