### PR TITLE
Viktig bugfix (firebase database)

### DIFF
--- a/App/pages/components/payment/paymentMethod.js
+++ b/App/pages/components/payment/paymentMethod.js
@@ -63,7 +63,7 @@ class PaymentMethod extends Component {
         firebase
           .database()
           .ref('users/' + user.uid)
-          .set({
+          .update({
             paymentCard: paymentCardTemp,
           });
       }


### PR DESCRIPTION
Tidigare så ändrades hela användarens objekt i databasen när man uppdaterade paymentCard. Detta resulterade i att om man hade en aktiv order och bytte kortnummer så försvann den aktiva ordern och modalen som visas när man scannat poppar upp. Detta löstes väldigt enkelt genom att byta ut funktionen `.set()` till `.update()` när man byter kortnummer.

#### Problemet uppstod vid följande steg:
Gör en betalning och byt sedan kortnummer på profilsidan (eller i checkout).